### PR TITLE
Use repo url in purl and extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ use `taskExtension` to map downloadLocations if they are cached somewhere other 
 ```kotlin
 tasks.withType<SpdxSbomTask> {
    taskExtension.set(object : SpdxSbomTaskExtension {
-       override fun mapDownloadUri(input: URI?): URI {
+       override fun mapRepoUri(input: URI?, moduleId: ModuleVersionIdentifier?): URI {
            // ignore input and return duck
-           return URI.create("https://duck.com")
+           return URI.create("https://duck.com/repository")
        }
        override fun mapScmForProject(original: ScmInfo?, projectInfo: ProjectInfo?): ScmInfo {
            // ignore provided scminfo (from extension) and project info (the project we are looking for scm info)

--- a/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
@@ -242,7 +242,10 @@ class SpdxSbomPluginFunctionalTest {
             + "}\n"
             + "tasks.withType<org.spdx.sbom.gradle.SpdxSbomTask> {\n"
             + "    taskExtension.set(object : org.spdx.sbom.gradle.extensions.SpdxSbomTaskExtension {\n"
-            + "        override fun mapDownloadUri(input: URI?): URI {\n"
+            + "        override fun mapRepoUri(input: URI?, moduleId: ModuleVersionIdentifier?): URI {\n"
+            + "            if (moduleId!!.name == \"sigstore-java\") {\n"
+            + "               return URI.create(\"https://truck.com\")\n"
+            + "            }\n"
             + "            // ignore input and return duck\n"
             + "            return URI.create(\"https://duck.com\")\n"
             + "        }\n"
@@ -282,8 +285,15 @@ class SpdxSbomPluginFunctionalTest {
     sbom.stream()
         .filter(line -> line.contains("downloadLocation"))
         .filter(line -> !line.contains("NOASSERTION"))
+        .filter(line -> !line.contains("/sigstore-java/"))
         .forEach(
             line -> MatcherAssert.assertThat(line, Matchers.containsString("https://duck.com")));
+    sbom.stream()
+        .filter(line -> line.contains("downloadLocation"))
+        .filter(line -> !line.contains("NOASSERTION"))
+        .filter(line -> line.contains("/sigstore-java/"))
+        .forEach(
+            line -> MatcherAssert.assertThat(line, Matchers.containsString("https://truck.com")));
     sbom.stream()
         .filter(line -> line.contains("sourceInfo"))
         .forEach(

--- a/src/main/java/org/spdx/sbom/gradle/extensions/DefaultSpdxSbomTaskExtension.java
+++ b/src/main/java/org/spdx/sbom/gradle/extensions/DefaultSpdxSbomTaskExtension.java
@@ -16,12 +16,13 @@
 package org.spdx.sbom.gradle.extensions;
 
 import java.net.URI;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.spdx.sbom.gradle.project.ProjectInfo;
 import org.spdx.sbom.gradle.project.ScmInfo;
 
 public abstract class DefaultSpdxSbomTaskExtension implements SpdxSbomTaskExtension {
   @Override
-  public URI mapDownloadUri(URI original) {
+  public URI mapRepoUri(URI original, ModuleVersionIdentifier moduleId) {
     return original;
   }
 

--- a/src/main/java/org/spdx/sbom/gradle/extensions/SpdxSbomTaskExtension.java
+++ b/src/main/java/org/spdx/sbom/gradle/extensions/SpdxSbomTaskExtension.java
@@ -16,11 +16,12 @@
 package org.spdx.sbom.gradle.extensions;
 
 import java.net.URI;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.spdx.sbom.gradle.project.ProjectInfo;
 import org.spdx.sbom.gradle.project.ScmInfo;
 
 public interface SpdxSbomTaskExtension {
-  URI mapDownloadUri(URI original);
+  URI mapRepoUri(URI original, ModuleVersionIdentifier moduleVersionIdentifier);
 
   ScmInfo mapScmForProject(ScmInfo original, ProjectInfo projectInfo);
 }

--- a/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
+++ b/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle.uri;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+
+public class URIs {
+  public static URI toDownloadLocation(
+      URI repoUri, ModuleVersionIdentifier moduleId, String filename) {
+    if (!repoUri.toString().endsWith("/")) {
+      repoUri = URI.create(repoUri.toString().concat("/"));
+    }
+    String modulePath =
+        moduleId.getGroup().replace(".", "/")
+            + "/"
+            + moduleId.getName()
+            + "/"
+            + moduleId.getVersion()
+            + "/"
+            + URLEncoder.encode(filename, StandardCharsets.UTF_8);
+    return repoUri.resolve(modulePath);
+  }
+
+  public static String toPurl(URI repoUri, ModuleVersionIdentifier moduleId) {
+    var locator =
+        "pkg:maven/" + moduleId.getGroup() + "/" + moduleId.getName() + "@" + moduleId.getVersion();
+    var repo = repoUri.toString();
+    repo = trimTrailingSlashes(repo);
+    if (!repo.equals("https://repo.maven.org/maven2")) {
+      repo = trimPrefix(repo, "http://");
+      repo = trimPrefix(repo, "https://");
+      locator = locator + ("?repository_url=" + URLEncoder.encode(repo, StandardCharsets.UTF_8));
+    }
+    return locator;
+  }
+
+  private static String trimPrefix(String str, String prefix) {
+    return str.replaceFirst("^" + prefix, "");
+  }
+
+  private static String trimTrailingSlashes(String str) {
+    return str.replaceFirst("/*$", "");
+  }
+}

--- a/src/test/java/org/spdx/sbom/gradle/uri/URIsTest.java
+++ b/src/test/java/org/spdx/sbom/gradle/uri/URIsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle.uri;
+
+import java.net.URI;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class URIsTest {
+  private static ModuleVersionIdentifier moduleId;
+  private static String filename;
+
+  @BeforeAll
+  public static void initModuleId() {
+    moduleId = DefaultModuleVersionIdentifier.newId("com.test", "test", "1.0.0");
+    filename = "test-1.0.0.jar";
+  }
+
+  @Test
+  public void toDownloadLocation() {
+    URI downloadLocation =
+        URIs.toDownloadLocation(URI.create("https://repo.maven.org/maven2"), moduleId, filename);
+    Assertions.assertEquals(
+        "https://repo.maven.org/maven2/com/test/test/1.0.0/test-1.0.0.jar",
+        downloadLocation.toString());
+  }
+
+  @Test
+  public void toDownloadLocation_withTrailingSlash() {
+    URI downloadLocation =
+        URIs.toDownloadLocation(URI.create("https://repo.maven.org/maven2/"), moduleId, filename);
+    Assertions.assertEquals(
+        "https://repo.maven.org/maven2/com/test/test/1.0.0/test-1.0.0.jar",
+        downloadLocation.toString());
+  }
+
+  @Test
+  public void toPurl_mavenCentral() {
+    String purl = URIs.toPurl(URI.create("https://repo.maven.org/maven2"), moduleId);
+    Assertions.assertEquals("pkg:maven/com.test/test@1.0.0", purl);
+  }
+
+  @Test
+  public void toPurl_otherRepo() {
+    String purl = URIs.toPurl(URI.create("https://repo.other.org/maven2"), moduleId);
+    Assertions.assertEquals(
+        "pkg:maven/com.test/test@1.0.0?repository_url=repo.other.org%2Fmaven2", purl);
+  }
+
+  @Test
+  public void toPurl_trailingSlashes() {
+    String purl = URIs.toPurl(URI.create("https://repo.other.org/maven2///"), moduleId);
+    Assertions.assertEquals(
+        "pkg:maven/com.test/test@1.0.0?repository_url=repo.other.org%2Fmaven2", purl);
+  }
+}


### PR DESCRIPTION
- breaking change to task extension mapDownloadUri is now mapRepoUri, should still work if mirrors are still repos
- purl now contains repository_url param