### PR TITLE
Make plugin JDK 8 compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ gradlePlugin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 val functionalTestSourceSet = sourceSets.create("functionalTest") {}

--- a/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
@@ -21,9 +21,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -113,7 +116,7 @@ class SpdxSbomPluginFunctionalTest {
     runner.withDebug(true);
     runner.withArguments("spdxSbomForRelease", "--stacktrace");
     runner.withProjectDir(projectDir);
-    var result = runner.build();
+    BuildResult result = runner.build();
 
     Path outputFile = projectDir.toPath().resolve(Paths.get("build/spdx/release.spdx.json"));
     Verify.verify(outputFile.toFile().getAbsolutePath(), SerFileType.JSON);
@@ -126,7 +129,9 @@ class SpdxSbomPluginFunctionalTest {
     // Verify the result
     assertTrue(Files.isRegularFile(outputFile));
 
-    System.out.println(Files.readString(outputFile));
+    System.out.println(
+        com.google.common.io.Files.asCharSource(outputFile.toFile(), Charset.defaultCharset())
+            .read());
   }
 
   @Test
@@ -175,12 +180,16 @@ class SpdxSbomPluginFunctionalTest {
     assertTrue(Files.isRegularFile(outputFile));
 
     // should contain both versions from both library references
-    var sbom = Files.readString(outputFile);
+    String sbom =
+        com.google.common.io.Files.asCharSource(outputFile.toFile(), Charset.defaultCharset())
+            .read();
     MatcherAssert.assertThat(sbom, Matchers.containsString("sigstore-java:0.2.0"));
     MatcherAssert.assertThat(sbom, Matchers.containsString("sigstore-java:0.3.0"));
     MatcherAssert.assertThat(sbom, Matchers.containsString("\"versionInfo\" : \"1.2.3\""));
 
-    System.out.println(Files.readString(outputFile));
+    System.out.println(
+        com.google.common.io.Files.asCharSource(outputFile.toFile(), Charset.defaultCharset())
+            .read());
   }
 
   @Test
@@ -281,7 +290,7 @@ class SpdxSbomPluginFunctionalTest {
 
     // Verify the result
     assertTrue(Files.isRegularFile(outputFile));
-    var sbom = Files.readAllLines(outputFile);
+    List<String> sbom = Files.readAllLines(outputFile);
     sbom.stream()
         .filter(line -> line.contains("downloadLocation"))
         .filter(line -> !line.contains("NOASSERTION"))

--- a/src/main/java/org/spdx/sbom/gradle/SpdxSbomPlugin.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxSbomPlugin.java
@@ -55,7 +55,8 @@ public class SpdxSbomPlugin implements Plugin<Project> {
             .getSharedServices()
             .registerIfAbsent(
                 "spdxKnownLicensesService", SpdxKnownLicensesService.class, spec -> {});
-    var extension = project.getExtensions().create("spdxSbom", SpdxSbomExtension.class);
+    SpdxSbomExtension extension =
+        project.getExtensions().create("spdxSbom", SpdxSbomExtension.class);
     extension
         .getTargets()
         .configureEach(
@@ -110,7 +111,7 @@ public class SpdxSbomPlugin implements Plugin<Project> {
                   t.usesService(knownLicenseServiceProvider);
 
                   List<String> configurationNames = target.getConfigurations().get();
-                  for (var configurationName : configurationNames) {
+                  for (String configurationName : configurationNames) {
                     Provider<Set<ResolvedArtifactResult>> artifacts =
                         project
                             .getConfigurations()

--- a/src/main/java/org/spdx/sbom/gradle/SpdxSbomTask.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxSbomTask.java
@@ -100,7 +100,7 @@ public abstract class SpdxSbomTask extends DefaultTask {
             getScmInfo().get(),
             getSpdxKnownLicensesService().get().getKnownLicenses());
 
-    for (var rootComponent : getRootComponents().get()) {
+    for (ResolvedComponentResult rootComponent : getRootComponents().get()) {
       documentBuilder.add(rootComponent);
     }
 

--- a/src/main/java/org/spdx/sbom/gradle/maven/GradleMavenResolver.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/GradleMavenResolver.java
@@ -15,6 +15,7 @@
  */
 package org.spdx.sbom.gradle.maven;
 
+import java.io.File;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Repository;
@@ -22,6 +23,7 @@ import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelSource2;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 
 public class GradleMavenResolver implements ModelResolver {
   private final Project project;
@@ -32,11 +34,11 @@ public class GradleMavenResolver implements ModelResolver {
 
   @Override
   public ModelSource2 resolveModel(String groupId, String artifactId, String version) {
-    var dep = groupId + ":" + artifactId + ":" + version + "@pom";
-    var dependency = project.getDependencies().create(dep);
-    var config = project.getConfigurations().detachedConfiguration(dependency);
+    String dep = groupId + ":" + artifactId + ":" + version + "@pom";
+    org.gradle.api.artifacts.Dependency dependency = project.getDependencies().create(dep);
+    Configuration config = project.getConfigurations().detachedConfiguration(dependency);
 
-    var pomXml = config.getSingleFile();
+    File pomXml = config.getSingleFile();
     return new FileModelSource(pomXml);
   }
 

--- a/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
@@ -32,6 +32,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.logging.Logger;
 
 /** This needs to be run *before* while configuring the task, so use it in the Plugin. */
@@ -56,8 +57,9 @@ public class PomResolver {
 
   public Map<String, PomInfo> effectivePoms(Configuration pomsConfig) {
     Map<String, PomInfo> effectivePoms = new HashMap<>();
-    for (var ra : pomsConfig.getIncoming().getArtifacts().getResolvedArtifacts().get()) {
-      var pomFile = ra.getFile();
+    for (ResolvedArtifactResult ra :
+        pomsConfig.getIncoming().getArtifacts().getResolvedArtifacts().get()) {
+      File pomFile = ra.getFile();
       Model model = resolveEffectivePom(pomFile);
       effectivePoms.put(
           ra.getId().getComponentIdentifier().getDisplayName(),

--- a/src/main/java/org/spdx/sbom/gradle/project/DocumentInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/DocumentInfo.java
@@ -45,14 +45,14 @@ public interface DocumentInfo {
   }
 
   static DocumentInfo from(SpdxSbomExtension.Target target) {
-    var document = target.getDocument();
-    var builder =
+    SpdxSbomExtension.Document document = target.getDocument();
+    ImmutableDocumentInfo.Builder builder =
         ImmutableDocumentInfo.builder()
             .name(document.getName().get())
             .namespace(document.getNamespace().get())
             .creator(Optional.ofNullable(document.getCreator().getOrNull()))
             .packageSupplier(Optional.ofNullable(document.getPackageSupplier().getOrNull()));
-    var rootPackage = target.getDocument().getRootPackage();
+    SpdxSbomExtension.RootPackage rootPackage = target.getDocument().getRootPackage();
     if (!rootPackage.getName().isPresent()
         && !rootPackage.getSupplier().isPresent()
         && !rootPackage.getVersion().isPresent()) {

--- a/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
+++ b/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
@@ -15,9 +15,9 @@
  */
 package org.spdx.sbom.gradle.uri;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
 public class URIs {
@@ -26,26 +26,35 @@ public class URIs {
     if (!repoUri.toString().endsWith("/")) {
       repoUri = URI.create(repoUri.toString().concat("/"));
     }
-    String modulePath =
-        moduleId.getGroup().replace(".", "/")
-            + "/"
-            + moduleId.getName()
-            + "/"
-            + moduleId.getVersion()
-            + "/"
-            + URLEncoder.encode(filename, StandardCharsets.UTF_8);
+    String modulePath;
+    try {
+      modulePath =
+          moduleId.getGroup().replace(".", "/")
+              + "/"
+              + moduleId.getName()
+              + "/"
+              + moduleId.getVersion()
+              + "/"
+              + URLEncoder.encode(filename, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
     return repoUri.resolve(modulePath);
   }
 
   public static String toPurl(URI repoUri, ModuleVersionIdentifier moduleId) {
-    var locator =
+    String locator =
         "pkg:maven/" + moduleId.getGroup() + "/" + moduleId.getName() + "@" + moduleId.getVersion();
-    var repo = repoUri.toString();
+    String repo = repoUri.toString();
     repo = trimTrailingSlashes(repo);
     if (!repo.equals("https://repo.maven.org/maven2")) {
       repo = trimPrefix(repo, "http://");
       repo = trimPrefix(repo, "https://");
-      locator = locator + ("?repository_url=" + URLEncoder.encode(repo, StandardCharsets.UTF_8));
+      try {
+        locator = locator + ("?repository_url=" + URLEncoder.encode(repo, "UTF-8"));
+      } catch (UnsupportedEncodingException e) {
+        throw new RuntimeException(e);
+      }
     }
     return locator;
   }

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxLicenses.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxLicenses.java
@@ -70,7 +70,7 @@ public class SpdxLicenses {
       return getOrCreateLicense(licenses.get(0));
     }
     List<AnyLicenseInfo> spdxLicenses = new ArrayList<>();
-    for (var license : licenses) {
+    for (LicenseInfo license : licenses) {
       spdxLicenses.add(getOrCreateLicense(license));
     }
     return doc.createConjunctiveLicenseSet(spdxLicenses);
@@ -91,7 +91,7 @@ public class SpdxLicenses {
     }
     // it's a known license
     if (knownLicenses.contains(license)) {
-      var knownLicense =
+      AnyLicenseInfo knownLicense =
           LicenseInfoFactory.parseSPDXLicenseString(
               knownLicenses.getIdFor(license), modelStore, doc.getDocumentUri(), copyManager);
       projectLicenses.put(normalizedLicenseUrl, knownLicense);
@@ -101,14 +101,14 @@ public class SpdxLicenses {
     // handle new unknown licenses
     // this is maybe not preferable, alternative is the user defining all the licenses
     logger.debug("Non spdx-standard license detected in package: " + license);
-    var unknownLicense = createNewUnknownLicense(license);
+    AnyLicenseInfo unknownLicense = createNewUnknownLicense(license);
     projectLicenses.put(normalizedLicenseUrl, unknownLicense);
     return unknownLicense;
   }
 
   private AnyLicenseInfo createNewUnknownLicense(LicenseInfo license)
       throws InvalidSPDXAnalysisException {
-    var licenseId = modelStore.getNextId(IdType.LicenseRef, doc.getDocumentUri());
+    String licenseId = modelStore.getNextId(IdType.LicenseRef, doc.getDocumentUri());
     ExtractedLicenseInfo unknown =
         new ExtractedLicenseInfo(modelStore, doc.getDocumentUri(), licenseId, copyManager, true);
     unknown.setName(license.getName());


### PR DESCRIPTION
In Kotlin project, we still use JDK 1.8 extensively for backward compatibility.

This change will enable usage for other older projects as well.