### PR TITLE
initial config for subproject pkg customization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,13 @@ gradlePlugin {
             description = "This plugin generates json formatted spdx sboms for gradle projects"
             tags.set(listOf("spdx", "sbom"))
         }
+        create("spdxPackage") {
+            id = "org.spdx.sbom-package"
+            implementationClass = "org.spdx.sbom.gradle.SpdxPackagePlugin"
+            displayName = "Companion plugin to org.spdx.sbom"
+            description = "This plugin enables customization of spdx package properties on subprojects"
+            tags.set(listOf("spdx", "sbom"))
+        }
     }
 }
 

--- a/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/spdx/SpdxSbomPluginFunctionalTest.java
@@ -98,7 +98,15 @@ class SpdxSbomPluginFunctionalTest {
 
     Path sub = projectDir.toPath().resolve("sub-project");
     Files.createDirectories(sub);
-    writeString(sub.resolve("build.gradle").toFile(), "plugins {\n" + "  id('java')\n" + "}\n");
+    writeString(
+        sub.resolve("build.gradle").toFile(),
+        "plugins {\n"
+            + "  id('org.spdx.sbom-package')\n"
+            + "  id('java')\n"
+            + "}\n"
+            + "spdxPackage {\n"
+            + "  supplier.set(\"someone\")\n"
+            + "}\n");
 
     Path lib = sub.resolve(Paths.get("src/main/java/lib/Lib.java"));
     Files.createDirectories(lib.getParent());

--- a/src/main/java/org/spdx/sbom/gradle/SpdxPackageExtension.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxPackageExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+
+public abstract class SpdxPackageExtension {
+  public abstract Property<String> getName();
+
+  public abstract Property<String> getVersion();
+
+  public abstract Property<String> getSupplier();
+
+  public abstract Property<Boolean> getCreatePackage();
+
+  @Nested
+  public abstract SpdxSbomExtension.Scm getScm();
+
+  public void scm(Action<? super SpdxSbomExtension.Scm> configure) {
+    configure.execute(getScm());
+  }
+
+  abstract class Scm {
+    public abstract Property<String> getTool();
+
+    public abstract Property<String> getUri();
+
+    public abstract Property<String> getRevision();
+  }
+}

--- a/src/main/java/org/spdx/sbom/gradle/SpdxPackagePlugin.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxPackagePlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.jetbrains.annotations.NotNull;
+
+public class SpdxPackagePlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(@NotNull Project project) {
+    var extension = project.getExtensions().create("spdxPackage", SpdxPackageExtension.class);
+    extension.getName().convention(project.getName());
+    extension.getVersion().convention(project.getVersion().toString());
+    extension.getCreatePackage().convention(true);
+  }
+}


### PR DESCRIPTION
So this is the setup for #10, it is not actually in use in sbom generation code yet. I still think it's the right thing to do for addition configuration of projects.

I think one can still do this from a single build file using `allprojects`/`subprojects`/`project(":xyz")` but I think build-logic is the right place to configure this across a ton of projects if it needs to be.