### PR TITLE
Make the resulting filename property public

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/SpdxSbomTask.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxSbomTask.java
@@ -68,7 +68,7 @@ public abstract class SpdxSbomTask extends DefaultTask {
   abstract MapProperty<String, PomInfo> getPoms();
 
   @Input
-  abstract Property<String> getFilename();
+  public abstract Property<String> getFilename();
 
   @Input
   abstract Property<DocumentInfo> getDocumentInfo();


### PR DESCRIPTION
It will help to manipulate the resulting file, for example, during publishing