### PR TITLE
Add supplier to maven packages

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/maven/PomInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PomInfo.java
@@ -18,7 +18,6 @@ package org.spdx.sbom.gradle.maven;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.maven.model.Organization;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value.Immutable;

--- a/src/main/java/org/spdx/sbom/gradle/maven/PomInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PomInfo.java
@@ -17,6 +17,9 @@ package org.spdx.sbom.gradle.maven;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.model.Organization;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value.Immutable;
 
@@ -27,10 +30,21 @@ public interface PomInfo {
 
   URI getHomepage();
 
+  Optional<Organization> getOrganization();
+
+  List<DeveloperInfo> getDevelopers();
+
   @Immutable
   interface LicenseInfo {
     String getUrl();
 
     String getName();
+  }
+
+  @Immutable
+  interface DeveloperInfo {
+    Optional<String> getName();
+
+    Optional<String> getEmail();
   }
 }

--- a/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
@@ -80,10 +80,8 @@ public class PomResolver {
                               ImmutableDeveloperInfo.builder()
                                   .name(Optional.ofNullable(d.getName()))
                                   .email(Optional.ofNullable(d.getEmail()))
-                                  .build()
-                      )
-                      .collect(Collectors.toList())
-              )
+                                  .build())
+                      .collect(Collectors.toList()))
               .build());
     }
     return effectivePoms;

--- a/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PomResolver.java
@@ -72,6 +72,18 @@ public class PomResolver {
                                   .build())
                       .collect(Collectors.toList()))
               .homepage(extractHomepage(model, ra.getId().getComponentIdentifier()))
+              .organization(Optional.ofNullable(model.getOrganization()))
+              .addAllDevelopers(
+                  model.getDevelopers().stream()
+                      .map(
+                          d ->
+                              ImmutableDeveloperInfo.builder()
+                                  .name(Optional.ofNullable(d.getName()))
+                                  .email(Optional.ofNullable(d.getEmail()))
+                                  .build()
+                      )
+                      .collect(Collectors.toList())
+              )
               .build());
     }
     return effectivePoms;

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -37,9 +37,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.annotation.Nullable;
-
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -353,9 +351,7 @@ public class SpdxDocumentBuilder {
 
       spdxPkgBuilder.setVersionInfo(moduleId.getVersion());
 
-      spdxPkgBuilder.setSupplier(
-          buildMavenPackageSupplier(pomInfo)
-      );
+      spdxPkgBuilder.setSupplier(buildMavenPackageSupplier(pomInfo));
 
       String sha1 =
           com.google.common.io.Files.asByteSource(dependencyFile).hash(Hashing.sha1()).toString();
@@ -372,17 +368,21 @@ public class SpdxDocumentBuilder {
   }
 
   private String buildMavenPackageSupplier(PomInfo pomInfo) {
-    var organizationName = pomInfo.getOrganization().flatMap(o ->
-        Optional.ofNullable(o.getName())).map(n ->
-        "Organization: " + n);
+    var organizationName =
+        pomInfo
+            .getOrganization()
+            .flatMap(o -> Optional.ofNullable(o.getName()))
+            .map(n -> "Organization: " + n);
 
-    var developer = pomInfo.getDevelopers().stream().filter(d -> d.getName().isPresent()).findFirst();
-    Optional<String> developerName = Stream.of(
-            developer.flatMap(d -> d.getName().map(name -> "Person: " + name)),
-            developer.flatMap(d -> d.getEmail().map(email -> " (" + email + ")"))
-        ).filter(Optional::isPresent)
-        .map(Optional::get)
-        .reduce((name, email) -> name + email);
+    var developer =
+        pomInfo.getDevelopers().stream().filter(d -> d.getName().isPresent()).findFirst();
+    Optional<String> developerName =
+        Stream.of(
+                developer.flatMap(d -> d.getName().map(name -> "Person: " + name)),
+                developer.flatMap(d -> d.getEmail().map(email -> " (" + email + ")")))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .reduce((name, email) -> name + email);
 
     return organizationName.orElseGet(() -> developerName.orElse("Organization: NOASSERTION"));
   }

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -36,7 +36,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import javax.annotation.Nullable;
+
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -350,6 +353,10 @@ public class SpdxDocumentBuilder {
 
       spdxPkgBuilder.setVersionInfo(moduleId.getVersion());
 
+      spdxPkgBuilder.setSupplier(
+          buildMavenPackageSupplier(pomInfo)
+      );
+
       String sha1 =
           com.google.common.io.Files.asByteSource(dependencyFile).hash(Hashing.sha1()).toString();
       var checksumSha1 = doc.createChecksum(ChecksumAlgorithm.SHA1, sha1);
@@ -362,6 +369,22 @@ public class SpdxDocumentBuilder {
       return Optional.of(spdxPkgBuilder.build());
     }
     return Optional.empty();
+  }
+
+  private String buildMavenPackageSupplier(PomInfo pomInfo) {
+    var organizationName = pomInfo.getOrganization().flatMap(o ->
+        Optional.ofNullable(o.getName())).map(n ->
+        "Organization: " + n);
+
+    var developer = pomInfo.getDevelopers().stream().filter(d -> d.getName().isPresent()).findFirst();
+    Optional<String> developerName = Stream.of(
+            developer.flatMap(d -> d.getName().map(name -> "Person: " + name)),
+            developer.flatMap(d -> d.getEmail().map(email -> " (" + email + ")"))
+        ).filter(Optional::isPresent)
+        .map(Optional::get)
+        .reduce((name, email) -> name + email);
+
+    return organizationName.orElseGet(() -> developerName.orElse("Organization: NOASSERTION"));
   }
 
   public SpdxDocument getSpdxDocument() {


### PR DESCRIPTION
Specify the PackageSupplier field using the name of the maven repository that the artifact was resolved from in order to adhere to the [NTIA required fields](https://spdx.github.io/spdx-ntia-sbom-howto/#_3_3_package_information_section_and_relationship_primary_package).

If no supplier is found, use `Organization: NOASSERTION`, as simply `NOASSERTION` doesn't pass the NTIA validator (the NTIA spec doesn't specify anything about this as far as I can tell).

There is currently an issue with retrieving the maven repository's name in Gradle 8.2, which is being discussed in the [Gradle Community Slack](https://gradle-community.slack.com/archives/CAHSN3LDN/p1688487582770519).