### PR TITLE
Handle NOASSERTION for download URI value

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/extensions/DefaultSpdxSbomTaskExtension.java
+++ b/src/main/java/org/spdx/sbom/gradle/extensions/DefaultSpdxSbomTaskExtension.java
@@ -18,12 +18,13 @@ package org.spdx.sbom.gradle.extensions;
 import java.net.URI;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spdx.sbom.gradle.project.ProjectInfo;
 import org.spdx.sbom.gradle.project.ScmInfo;
 
 public abstract class DefaultSpdxSbomTaskExtension implements SpdxSbomTaskExtension {
   @Override
-  public URI mapRepoUri(@NotNull URI original, @NotNull ModuleVersionIdentifier moduleId) {
+  public URI mapRepoUri(@Nullable URI original, @NotNull ModuleVersionIdentifier moduleId) {
     return original;
   }
 

--- a/src/main/java/org/spdx/sbom/gradle/extensions/SpdxSbomTaskExtension.java
+++ b/src/main/java/org/spdx/sbom/gradle/extensions/SpdxSbomTaskExtension.java
@@ -18,11 +18,12 @@ package org.spdx.sbom.gradle.extensions;
 import java.net.URI;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spdx.sbom.gradle.project.ProjectInfo;
 import org.spdx.sbom.gradle.project.ScmInfo;
 
 public interface SpdxSbomTaskExtension {
-  URI mapRepoUri(@NotNull URI original, @NotNull ModuleVersionIdentifier moduleVersionIdentifier);
+  URI mapRepoUri(@Nullable URI original, @NotNull ModuleVersionIdentifier moduleVersionIdentifier);
 
   ScmInfo mapScmForProject(@NotNull ScmInfo original, @NotNull ProjectInfo projectInfo);
 

--- a/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
+++ b/src/main/java/org/spdx/sbom/gradle/uri/URIs.java
@@ -23,6 +23,9 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 public class URIs {
   public static URI toDownloadLocation(
       URI repoUri, ModuleVersionIdentifier moduleId, String filename) {
+    if ("NOASSERTION".equals(repoUri.toString())) {
+      return repoUri;
+    }
     if (!repoUri.toString().endsWith("/")) {
       repoUri = URI.create(repoUri.toString().concat("/"));
     }
@@ -38,11 +41,11 @@ public class URIs {
   }
 
   public static String toPurl(URI repoUri, ModuleVersionIdentifier moduleId) {
+    var repo = repoUri.toString();
     var locator =
         "pkg:maven/" + moduleId.getGroup() + "/" + moduleId.getName() + "@" + moduleId.getVersion();
-    var repo = repoUri.toString();
     repo = trimTrailingSlashes(repo);
-    if (!repo.equals("https://repo.maven.org/maven2")) {
+    if (!repo.equals("https://repo.maven.org/maven2") && !repo.equals("NOASSERTION")) {
       repo = trimPrefix(repo, "http://");
       repo = trimPrefix(repo, "https://");
       locator = locator + ("?repository_url=" + URLEncoder.encode(repo, StandardCharsets.UTF_8));

--- a/src/test/java/org/spdx/sbom/gradle/uri/URIsTest.java
+++ b/src/test/java/org/spdx/sbom/gradle/uri/URIsTest.java
@@ -51,6 +51,12 @@ class URIsTest {
   }
 
   @Test
+  public void toDownloadLocation_noassertion() {
+    URI downloadLocation = URIs.toDownloadLocation(URI.create("NOASSERTION"), moduleId, filename);
+    Assertions.assertEquals("NOASSERTION", downloadLocation.toString());
+  }
+
+  @Test
   public void toPurl_mavenCentral() {
     String purl = URIs.toPurl(URI.create("https://repo.maven.org/maven2"), moduleId);
     Assertions.assertEquals("pkg:maven/com.test/test@1.0.0", purl);
@@ -68,5 +74,11 @@ class URIsTest {
     String purl = URIs.toPurl(URI.create("https://repo.other.org/maven2///"), moduleId);
     Assertions.assertEquals(
         "pkg:maven/com.test/test@1.0.0?repository_url=repo.other.org%2Fmaven2", purl);
+  }
+
+  @Test
+  public void toPurl_noassertion() {
+    String purl = URIs.toPurl(URI.create("NOASSERTION"), moduleId);
+    Assertions.assertEquals("pkg:maven/com.test/test@1.0.0", purl);
   }
 }


### PR DESCRIPTION
According to SPDX specification section 7.7
https://spdx.github.io/spdx-spec/v2.3/package-information/

This enables a workaround for Gradle 8.2 which no more allows to retrieve downloadUrl from resolved artifact

Sample workaround:
```kotlin
tasks.withType<SpdxSbomTask>().configureEach {
    taskExtension.set(object : DefaultSpdxSbomTaskExtension() {
        private val NOASSERTION = URI.create("NOASSERTION")
        override fun mapRepoUri(input: URI?, moduleId: ModuleVersionIdentifier): URI {
            return NOASSERTION
        }
    })
}
```

Maybe `"NONE"` value should be used if `repoUri` is `null`

refs: #29 #30 