### PR TITLE
Use root document supplier field value for project modules in SBOM

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -266,12 +266,9 @@ public class SpdxDocumentBuilder {
               + " has no specified version");
       version = "NOASSERTION";
     }
-    var supplier = "NOASSERTION";
-    if (pi == describesProject) {
-      supplier = documentInfo.getPackageSupplier().orElse("NOASSERTION");
-      if (supplier.equals("NOASSERTION")) {
-        logger.warn("supplier not set for project " + pi.getName());
-      }
+    var supplier = documentInfo.getPackageSupplier().orElse("NOASSERTION");
+    if (supplier.equals("NOASSERTION")) {
+      logger.warn("supplier not set for project " + pi.getName());
     }
     SpdxPackageBuilder builder =
         doc.createPackage(


### PR DESCRIPTION
Assuming that all modules in the same project built from source should have the same supplier