### PR TITLE
Invoke extension mapRepoUri even if repoUri is null

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -329,7 +329,7 @@ public class SpdxDocumentBuilder {
       // Gradle 8.2 has an issue that causes sourceRepo to be a generated id instead of the name
       // Gradle 8.2.1 resolved that issue
       var repoUri = mavenArtifactRepositories.get(sourceRepo);
-      if (taskExtension != null && repoUri != null) {
+      if (taskExtension != null) {
         repoUri = taskExtension.mapRepoUri(repoUri, moduleId);
       }
       if (repoUri == null) {


### PR DESCRIPTION
I am not sure when this happens, but I see it with my project causing my extension not not be called.

I was not able to write a test where `repoUri` was `null`.