### PR TITLE
Read sub project spdx package info

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/SpdxPackagePlugin.java
+++ b/src/main/java/org/spdx/sbom/gradle/SpdxPackagePlugin.java
@@ -27,5 +27,6 @@ public class SpdxPackagePlugin implements Plugin<Project> {
     extension.getName().convention(project.getName());
     extension.getVersion().convention(project.getVersion().toString());
     extension.getCreatePackage().convention(true);
+    extension.getScm().getTool().convention("git");
   }
 }

--- a/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.Project;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value.Immutable;
+import org.spdx.sbom.gradle.SpdxPackageExtension;
 
 @Immutable
 @Serial.Version(1)
@@ -38,15 +39,25 @@ public interface ProjectInfo {
 
   String getGroup();
 
+  Optional<SpdxPackageInfo> getPackageInfo();
+
   static ProjectInfo from(Project project) {
-    return ImmutableProjectInfo.builder()
-        .name(project.getName())
-        .description(Optional.ofNullable(project.getDescription()))
-        .version(project.getVersion().toString())
-        .projectDirectory(project.getProjectDir())
-        .path(project.getPath())
-        .group(project.getGroup().toString())
-        .build();
+    var builder =
+        ImmutableProjectInfo.builder()
+            .name(project.getName())
+            .description(Optional.ofNullable(project.getDescription()))
+            .version(project.getVersion().toString())
+            .projectDirectory(project.getProjectDir())
+            .path(project.getPath())
+            .group(project.getGroup().toString());
+
+    // find any spdxPackageExtension information
+    var ext = project.getExtensions().findByType(SpdxPackageExtension.class);
+    if (ext != null) {
+      builder.packageInfo(SpdxPackageInfo.from(ext));
+    }
+
+    return builder.build();
   }
 
   static Set<ProjectInfo> from(Set<Project> projects) {

--- a/src/main/java/org/spdx/sbom/gradle/project/SpdxPackageInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/SpdxPackageInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle.project;
+
+import java.util.Optional;
+import org.immutables.serial.Serial;
+import org.immutables.value.Value.Immutable;
+import org.spdx.sbom.gradle.SpdxPackageExtension;
+
+@Immutable
+@Serial.Version(1)
+public interface SpdxPackageInfo {
+
+  String getName();
+
+  String getVersion();
+
+  boolean getCreatePackage();
+
+  Optional<ScmInfo> getScmInfo();
+
+  Optional<String> getSupplier();
+
+  static SpdxPackageInfo from(SpdxPackageExtension ext) {
+    if (ext == null) {
+      throw new NullPointerException("Extension value cannot be null");
+    }
+    var builder =
+        ImmutableSpdxPackageInfo.builder()
+            .name(ext.getName().get())
+            .version(ext.getVersion().get())
+            .createPackage(ext.getCreatePackage().get())
+            .supplier(Optional.ofNullable(ext.getSupplier().getOrNull()));
+
+    var scm = ext.getScm();
+    if (scm.getRevision().isPresent() && scm.getTool().isPresent() && scm.getUri().isPresent()) {
+      builder.scmInfo(
+          ScmInfo.from(scm.getTool().get(), scm.getUri().get(), scm.getRevision().get()));
+    }
+    // this default should be set by the plugin, if it is missing something is wrong
+    if (!scm.getTool().isPresent()) {
+      throw new IllegalStateException("no default scm tool was configured by the plugin");
+    }
+
+    if ((scm.getUri().isPresent() && !scm.getRevision().isPresent())
+        || (!scm.getUri().isPresent() && scm.getRevision().isPresent())) {
+      throw new IllegalArgumentException(
+          "uri and revision must be set if specifying scm info on spdx package extension (project: "
+              + ext.getName().get()
+              + ")");
+    }
+    return builder.build();
+  }
+}

--- a/src/test/java/org/spdx/sbom/gradle/project/SpdxPackageInfoTest.java
+++ b/src/test/java/org/spdx/sbom/gradle/project/SpdxPackageInfoTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle.project;
+
+import java.util.Optional;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.spdx.sbom.gradle.SpdxPackageExtension;
+
+class SpdxPackageInfoTest {
+
+  @Test
+  void from_null() {
+    Assertions.assertThrows(NullPointerException.class, () -> SpdxPackageInfo.from(null));
+  }
+
+  @Test
+  void from_valid() {
+    Project project = ProjectBuilder.builder().build();
+    project.getPlugins().apply("org.spdx.sbom-package");
+    project
+        .getExtensions()
+        .configure(
+            SpdxPackageExtension.class,
+            ext -> {
+              ext.getName().set("test-name");
+              ext.getVersion().set("test-version");
+              ext.getSupplier().set("test-supplier");
+              ext.getCreatePackage().set(false);
+              ext.getScm().getUri().set("git.test.com");
+              ext.getScm().getRevision().set("test-revision");
+              ext.getScm().getTool().set("cvs");
+            });
+
+    var ext = SpdxPackageInfo.from(project.getExtensions().getByType(SpdxPackageExtension.class));
+    Assertions.assertEquals("test-name", ext.getName());
+    Assertions.assertEquals("test-version", ext.getVersion());
+    Assertions.assertFalse(ext.getCreatePackage());
+    Assertions.assertEquals(Optional.of("test-supplier"), ext.getSupplier());
+    Assertions.assertEquals(
+        Optional.of(ScmInfo.from("cvs", "git.test.com", "test-revision")), ext.getScmInfo());
+  }
+
+  @Test
+  void from_defaults() {
+    Project project = ProjectBuilder.builder().withName("test-name").build();
+    project.setVersion("test-version");
+    project.getPlugins().apply("org.spdx.sbom-package");
+
+    var ext = SpdxPackageInfo.from(project.getExtensions().getByType(SpdxPackageExtension.class));
+    Assertions.assertEquals("test-name", ext.getName());
+    Assertions.assertEquals("test-version", ext.getVersion());
+    Assertions.assertTrue(ext.getCreatePackage());
+    Assertions.assertEquals(Optional.empty(), ext.getSupplier());
+    Assertions.assertEquals(Optional.empty(), ext.getScmInfo());
+  }
+
+  @Test
+  void from_scmErrorNoRevision() {
+    Project project = ProjectBuilder.builder().withName("test-name").build();
+    project.setVersion("test-version");
+    project.getPlugins().apply("org.spdx.sbom-package");
+
+    project
+        .getExtensions()
+        .configure(
+            SpdxPackageExtension.class,
+            ext -> {
+              ext.getScm().getUri().set("git.test.com");
+            });
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> SpdxPackageInfo.from(project.getExtensions().getByType(SpdxPackageExtension.class)));
+  }
+
+  @Test
+  void from_scmErrorNoUri() {
+    Project project = ProjectBuilder.builder().withName("test-name").build();
+    project.setVersion("test-version");
+    project.getPlugins().apply("org.spdx.sbom-package");
+
+    project
+        .getExtensions()
+        .configure(
+            SpdxPackageExtension.class,
+            ext -> {
+              ext.getScm().getRevision().set("test-revision");
+            });
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> SpdxPackageInfo.from(project.getExtensions().getByType(SpdxPackageExtension.class)));
+  }
+}


### PR DESCRIPTION
This is still a partial impl of the feature, this just reads in the package info and makes it available to a task. We do not integrate into the spdx document yet.


The integration plan would be to pull information from this extension for subprojects when avaiable. They would be the highest priority source of data for sub pkgs *except* for the task extension which may override anything (but people should generally not be using)