### PR TITLE
Handle duplicate files references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can build and deploy locally and then use in your project
 Install into local maven
 ```bash
 $ git clone git@github.com:spdx/spdx-gradle-plugin
-$ ./gradlew publishToMavenLocal
+$ ./gradlew publishToMavenLocal -Pskip.signing
 ```
 
 Add mavenLocal as a plugin repository (settings.gradle.kts)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,10 @@ tasks.withType<AbstractArchiveTask>().configureEach {
     isReproducibleFileOrder = true
 }
 
+tasks.withType<Sign> {
+    onlyIf("skip.signing is not set") { !project.hasProperty("skip.signing") }
+}
+
 signing {
     val signingKey: String? by project
     val signingPassword: String? by project

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -160,7 +161,17 @@ public class SpdxDocumentBuilder {
 
     this.resolvedArtifacts =
         resolvedArtifacts.entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().getComponentIdentifier(), Entry::getValue));
+            .collect(
+                Collectors.toMap(
+                    e -> e.getKey().getComponentIdentifier(),
+                    Entry::getValue,
+                    (file1, file2) -> {
+                      if (Objects.equals(file1, file2)) {
+                        return file1;
+                      } else
+                        throw new IllegalStateException(
+                            "cannot merge duplicate " + file1 + " and " + file2);
+                    }));
     this.mavenArtifactRepositories = mavenArtifactRepositories;
     this.poms = poms;
 


### PR DESCRIPTION
It looks like sometimes android projects will have dependency references through two different objects to same file? Its not exactly clear why?
- ModuleComponentFileArtifactIdentifier
- DefaultModuleComponentArtifactIdentifier

Also allow skip signing when building this plugin for local testing