### PR TITLE
Use versionName for version for Android app projects

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/internal/AndroidVersionLoader.java
+++ b/src/main/java/org/spdx/sbom/gradle/internal/AndroidVersionLoader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spdx.sbom.gradle.internal;
+
+import java.lang.reflect.Method;
+import org.gradle.api.Project;
+
+public class AndroidVersionLoader {
+  public String getApplicationVersion(Project project) {
+    Object android = project.getExtensions().findByName("android");
+    if (android != null) {
+      try {
+        Method defaultConfig = android.getClass().getMethod("getDefaultConfig");
+        Object configInstance = defaultConfig.invoke(android);
+        Method getVersionName = configInstance.getClass().getMethod("getVersionName");
+        return (String) getVersionName.invoke(configInstance);
+      } catch (Throwable t) {
+        new Object();
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.Project;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value.Immutable;
+import org.spdx.sbom.gradle.internal.AndroidVersionLoader;
 
 @Immutable
 @Serial.Version(1)
@@ -42,11 +43,24 @@ public interface ProjectInfo {
     return ImmutableProjectInfo.builder()
         .name(project.getName())
         .description(Optional.ofNullable(project.getDescription()))
-        .version(project.getVersion().toString())
+        .version(version(project))
         .projectDirectory(project.getProjectDir())
         .path(project.getPath())
         .group(project.getGroup().toString())
         .build();
+  }
+
+  static String version(Project project) {
+    String version = project.getVersion().toString();
+
+    if (project.getPlugins().hasPlugin("com.android.application")) {
+      String androidVersion = new AndroidVersionLoader().getApplicationVersion(project);
+      if (androidVersion != null) {
+        version = androidVersion;
+      }
+    }
+
+    return version;
   }
 
   static Set<ProjectInfo> from(Set<Project> projects) {


### PR DESCRIPTION
Fixes #79 

Technically the correct way to do this would be through the Android variants API. However that could get complicated with this library's Target API, so I didn't do that for now.