### PR TITLE
rename packageSupplier to supplier for consistency

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/project/DocumentInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/DocumentInfo.java
@@ -32,7 +32,7 @@ public interface DocumentInfo {
 
   Optional<UberPackageInfo> getUberPackageInfo();
 
-  Optional<String> getPackageSupplier();
+  Optional<String> getSupplier();
 
   @Immutable
   @Serial.Version(1)
@@ -51,7 +51,7 @@ public interface DocumentInfo {
             .name(document.getName().get())
             .namespace(document.getNamespace().get())
             .creator(Optional.ofNullable(document.getCreator().getOrNull()))
-            .packageSupplier(Optional.ofNullable(document.getPackageSupplier().getOrNull()));
+            .supplier(Optional.ofNullable(document.getPackageSupplier().getOrNull()));
     var uberPackage = target.getDocument().getUberPackage();
     if (!uberPackage.getName().isPresent()
         && !uberPackage.getSupplier().isPresent()

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -282,7 +282,7 @@ public class SpdxDocumentBuilder {
               + " has no specified version");
       version = "NOASSERTION";
     }
-    var supplier = documentInfo.getPackageSupplier().orElse("NOASSERTION");
+    var supplier = documentInfo.getSupplier().orElse("NOASSERTION");
     if (supplier.equals("NOASSERTION")) {
       logger.warn("supplier not set for project " + pi.getName());
     }


### PR DESCRIPTION
this was weird naming, correcting it now before 1.0.0

we will have to do a doc update after releasing this and the other few prs from eli