### PR TITLE
Set root supplier for submodules from the same root

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
+++ b/src/main/java/org/spdx/sbom/gradle/project/ProjectInfo.java
@@ -29,6 +29,8 @@ import org.spdx.sbom.gradle.internal.AndroidVersionLoader;
 public interface ProjectInfo {
   String getName();
 
+  String getRootName();
+
   Optional<String> getDescription();
 
   String getVersion();
@@ -42,6 +44,7 @@ public interface ProjectInfo {
   static ProjectInfo from(Project project) {
     return ImmutableProjectInfo.builder()
         .name(project.getName())
+        .rootName(project.getRootProject().getName())
         .description(Optional.ofNullable(project.getDescription()))
         .version(version(project))
         .projectDirectory(project.getProjectDir())

--- a/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/sbom/gradle/utils/SpdxDocumentBuilder.java
@@ -282,9 +282,12 @@ public class SpdxDocumentBuilder {
               + " has no specified version");
       version = "NOASSERTION";
     }
-    var supplier = documentInfo.getSupplier().orElse("NOASSERTION");
-    if (supplier.equals("NOASSERTION")) {
-      logger.warn("supplier not set for project " + pi.getName());
+    var supplier = "NOASSERTION";
+    if (pi == describesProject || pi.getRootName().equals(describesProject.getRootName())) {
+      supplier = documentInfo.getSupplier().orElse("NOASSERTION");
+      if (supplier.equals("NOASSERTION")) {
+        logger.warn("supplier not set for project " + pi.getName());
+      }
     }
     SpdxPackageBuilder builder =
         doc.createPackage(


### PR DESCRIPTION
This MR fixes cases when there are big multimodule projects (e.g. `kotlin`) and for separately released submodules supplier is ignored in dependencies