### PR TITLE
Fix path errors while analyzing packages referencing ${java.home}

### DIFF
--- a/src/main/java/org/spdx/sbom/gradle/maven/PropertiesForPom.java
+++ b/src/main/java/org/spdx/sbom/gradle/maven/PropertiesForPom.java
@@ -29,7 +29,7 @@ public abstract class PropertiesForPom {
 
   PropertiesForPom() {}
 
-  private static final List<String> JAVA_PROP_KEYS = List.of("java.version");
+  private static final List<String> JAVA_PROP_KEYS = List.of("java.version", "java.home");
 
   @Lazy
   public Properties get() {


### PR DESCRIPTION
Some packages (e.g., Javassist) refere ${java.home} in <systemPath> of their dependencies. This commit add "java.home" to the passthrough properties list and prevent maven from complaining such paths are not absolute.

```
Caused by: org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for org.javassist:javassist:3.29.2-GA
[ERROR] 'dependencies.dependency.systemPath' for com.sun:tools:jar must specify an absolute path but is ${java.home}/lib/jrt-fs.jar @ 

	at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException(DefaultModelProblemCollector.java:176)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:508)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:410)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:243)
	at org.spdx.sbom.gradle.maven.PomResolver.resolveEffectivePom(PomResolver.java:207)
	... 93 more
```